### PR TITLE
sepolicy: Define hal_cne_hwservice

### DIFF
--- a/sepolicy/hwservice.te
+++ b/sepolicy/hwservice.te
@@ -1,4 +1,4 @@
 type nxpnfc_hwservice, hwservice_manager_type;
 type nxpese_hwservice, hwservice_manager_type;
 type fpc_extension_service, hwservice_manager_type;
-
+type hal_cne_hwservice, hwservice_manager_type;


### PR DESCRIPTION
Fix sepolicy errors for files that depend on Hw service manager.